### PR TITLE
fix(mobile): improve keyboard handling and safe area management

### DIFF
--- a/apps/mobile/smarTODO/app/login.tsx
+++ b/apps/mobile/smarTODO/app/login.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import {
   Alert,
-  SafeAreaView,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Text } from "@tamagui/core";
 import { YStack, XStack } from "@tamagui/stacks";
 import { Button } from "@tamagui/button";
@@ -50,12 +50,18 @@ export default function LoginScreen() {
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
       <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        behavior={Platform.OS === "ios" ? "padding" : "padding"}
         style={{ flex: 1 }}
+        keyboardVerticalOffset={Platform.OS === "android" ? -100 : 0}
       >
-        <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+          bounces={false}
+          showsVerticalScrollIndicator={false}
+        >
           <YStack
             flex={1}
             padding="$6"

--- a/apps/mobile/smarTODO/app/reset-password.tsx
+++ b/apps/mobile/smarTODO/app/reset-password.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import {
   Alert,
-  SafeAreaView,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Text } from "@tamagui/core";
 import { YStack, XStack } from "@tamagui/stacks";
 import { Button } from "@tamagui/button";
@@ -68,12 +68,18 @@ export default function ResetPasswordScreen() {
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
       <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        behavior={Platform.OS === "ios" ? "padding" : "padding"}
         style={{ flex: 1 }}
+        keyboardVerticalOffset={Platform.OS === "android" ? -100 : 0}
       >
-        <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+          bounces={false}
+          showsVerticalScrollIndicator={false}
+        >
           <YStack flex={1} padding="$6" backgroundColor="$background">
             <XStack marginBottom="$4" alignItems="center">
               <Button

--- a/apps/mobile/smarTODO/app/signup.tsx
+++ b/apps/mobile/smarTODO/app/signup.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import {
   Alert,
-  SafeAreaView,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Text, View } from "@tamagui/core";
 import { YStack, XStack } from "@tamagui/stacks";
 import { Button } from "@tamagui/button";
@@ -84,7 +84,7 @@ export default function SignupScreen() {
 
   if (submitted) {
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
         <YStack
           flex={1}
           padding="$6"
@@ -150,12 +150,18 @@ export default function SignupScreen() {
   }
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
       <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        behavior={Platform.OS === "ios" ? "padding" : "padding"}
         style={{ flex: 1 }}
+        keyboardVerticalOffset={Platform.OS === "android" ? -100 : 0}
       >
-        <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+          bounces={false}
+          showsVerticalScrollIndicator={false}
+        >
           <YStack
             flex={1}
             padding="$6"

--- a/apps/mobile/smarTODO/app/update-password.tsx
+++ b/apps/mobile/smarTODO/app/update-password.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from "react";
 import {
   Alert,
-  SafeAreaView,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Text } from "@tamagui/core";
 import { YStack, XStack } from "@tamagui/stacks";
 import { Button } from "@tamagui/button";
@@ -137,12 +137,18 @@ export default function UpdatePasswordScreen() {
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
       <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        behavior={Platform.OS === "ios" ? "padding" : "padding"}
         style={{ flex: 1 }}
+        keyboardVerticalOffset={Platform.OS === "android" ? -100 : 0}
       >
-        <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+          bounces={false}
+          showsVerticalScrollIndicator={false}
+        >
           <YStack flex={1} padding="$6" backgroundColor="$background">
             <XStack marginBottom="$4" alignItems="center">
               <Button


### PR DESCRIPTION
# Pull Request

## 📋 Summary

This PR fixes keyboard handling and safe area management issues on Android devices, specifically addressing the blank area that appears after keyboard dismissal and improving overall keyboard avoidance behavior across authentication screens.

## 📦 Affected Packages

- [x] 📱 Mobile App (`apps/mobile/smarTODO`)
- [ ] 🌐 Web App (`apps/web`)
- [ ] 📚 Shared Packages (`packages/*`)
- [ ] ⚙️ Configuration (Lerna, workspace, build)
- [ ] 🔧 Development Tools
- [ ] 📖 Documentation
- [ ] 🏗️ CI/CD

## 🔄 Type of Change

- [ ] ✨ New feature (`feat`)
- [x] 🐛 Bug fix (`fix`)
- [ ] 📝 Documentation update (`docs`)
- [ ] 🎨 Code style/formatting (`style`)
- [ ] ♻️ Code refactoring (`refactor`)
- [ ] ✅ Tests (`test`)
- [ ] 🔧 Chores/maintenance (`chore`)
- [ ] ⚡ Performance improvement (`perf`)
- [ ] 🚀 CI/CD changes (`ci`)
- [ ] 📦 Build system changes (`build`)

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [x] Cross-package compatibility verified

**Test Instructions:**

1. Open the app on an Android device/emulator
2. Navigate to Login, Signup, Reset Password, and Update Password screens
3. Focus on input fields to trigger keyboard
4. Dismiss keyboard and verify no blank space remains at the bottom
5. Verify smooth scrolling behavior when keyboard is visible

## 📱 Mobile Testing (if applicable)

- [ ] iOS tested
- [x] Android tested
- [x] Expo development build tested

## 🌐 Web Testing (if applicable)

- [ ] Desktop browsers tested
- [ ] Mobile browsers tested
- [ ] Responsive design verified

## 🔗 Dependencies

- [x] This PR has no dependencies
- [ ] This PR depends on: #[issue/PR number]
- [ ] This PR blocks: #[issue/PR number]

## 📸 Screenshots/Videos

<!-- Add screenshots or videos to help explain your changes -->

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is commented where necessary
- [ ] Corresponding changes to documentation made
- [x] No new warnings introduced
- [x] All tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Commit messages follow [conventional commit format](../.gitmessage)

## 🚨 Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)

## 📝 Additional Notes

### Changes Made:
- Replaced React Native's built-in `SafeAreaView` with `react-native-safe-area-context` for better cross-platform support
- Added consistent `keyboardVerticalOffset={-100}` to all `KeyboardAvoidingView` components on Android
- Configured `keyboardShouldPersistTaps="handled"` on ScrollViews to improve tap handling
- Standardized keyboard avoidance implementation across all authentication screens (login, signup, reset-password, update-password)

### Issue Fixed:
Resolves the Android-specific issue where dismissing the keyboard would leave a blank area at the bottom of the screen, improving the user experience during authentication flows.

---

**Commit Message Preview:**

```
fix(mobile): improve keyboard handling and safe area management

- Replace React Native SafeAreaView with react-native-safe-area-context
- Add consistent keyboardVerticalOffset of -100 for Android
- Fix keyboard dismissal blank area issue on Android
- Improve ScrollView behavior with keyboardShouldPersistTaps
- Standardize keyboard avoidance across all auth screens
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Prevented keyboard from obscuring fields on Login, Signup, Reset Password, and Update Password screens.
  - Ensured proper top safe-area padding for consistent header spacing.
  - Improved scrolling: taps on inputs persist, bounce disabled, and scroll indicators hidden for cleaner UX.

- Refactor
  - Standardized keyboard handling across platforms with consistent padding and offset behavior.
  - Unified safe-area handling using top-edge-only insets for a more predictable layout across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->